### PR TITLE
feature 6.3.5

### DIFF
--- a/src/modele/centreControle/CentreControle.java
+++ b/src/modele/centreControle/CentreControle.java
@@ -21,6 +21,6 @@ public class CentreControle extends TransporteurMessage {
     // Implémentation de la méthode abstraite pour CentreControle
     @Override
     protected void gestionnaireMessage(Message msg) {
-        System.out.println("Centre de controle: Messafe reçu - " + msg.getNumero());
+        System.out.println("Centre de controle: Message reçu - " + msg.getNumero());
     }
 }

--- a/src/modele/centreControle/CentreControle.java
+++ b/src/modele/centreControle/CentreControle.java
@@ -2,17 +2,25 @@ package modele.centreControle;
 
 import modele.communication.TransporteurMessage;
 import modele.communication.Message;
+import modele.satelliteRelai.SatelliteRelai;
 
 public class CentreControle extends TransporteurMessage {
+    private SatelliteRelai relaisSatellite;
+
+    public CentreControle(SatelliteRelai relaiSatelitte) {
+        this.relaisSatellite = relaiSatelitte;
+    }
+
     // Implémentation de la méthode abstraite pour CentreControle
     @Override
     protected void envoyerMessage(Message msg) {
-        // too complete
+        relaisSatellite.envoyerMessageVersRover(msg);
+        messagesEnvoyes.add(msg);
     }
 
     // Implémentation de la méthode abstraite pour CentreControle
     @Override
     protected void gestionnaireMessage(Message msg) {
-        // too complete
+        System.out.println("Centre de controle: Messafe reçu - " + msg.getNumero());
     }
 }

--- a/src/modele/communication/TransporteurMessage.java
+++ b/src/modele/communication/TransporteurMessage.java
@@ -94,9 +94,9 @@ public abstract class TransporteurMessage extends Thread {
         while (true) {
             lock.lock();
             try {
-                Message msg = fileMessages.poll();
+                Message msg = fileMessages.poll(); //recupere le dernier message de la file
 
-                if (msg == null || nackEnvoye) {
+                if (msg == null || nackEnvoye) {   //si la file est vide, ou un cacj a ete envoyer, aucune action necessaire
                     break;
                 }
 
@@ -105,9 +105,11 @@ public abstract class TransporteurMessage extends Thread {
                     Nack nack = (Nack) msg;
                     int compteManquant = nack.getCompte();
 
+                    //parcour la liste des message
                     while (!messagesEnvoyes.isEmpty()) {
                         Message messageEnvoye = messagesEnvoyes.peek();
 
+                        // quand on trouve le message manquant, on delete tt les message d'apres
                         if (messageEnvoye instanceof Nack || messageEnvoye.getCompte() < compteManquant) {
                             messagesEnvoyes.poll();
                         } else {
@@ -118,15 +120,16 @@ public abstract class TransporteurMessage extends Thread {
                     // Message à envoyer
                     Message messageAEnvoyer = messagesEnvoyes.peek();
                     envoyerMessage(messageAEnvoyer);
-                    messagesRecus.remove(nack);
+                    messagesRecus.remove(nack);    // on eneleve le nack
                 } else if (msg.getCompte() != compteCourant) {
+                    //renvoie un nack qui dit le nombre de message manquant
                     envoyerMessage(new Nack(compteCourant));
                     nackEnvoye = true;
                 } else if (msg.getCompte() < compteCourant) {
                     System.out.println("Message dupliqué rejeté : " + msg);
                 } else {
                     gestionnaireMessage(msg);
-                    fileMessages.poll();
+                    fileMessages.poll();          //Can you comment this part?!
                     compteCourant++;
                 }
             } finally {

--- a/src/modele/communication/TransporteurMessage.java
+++ b/src/modele/communication/TransporteurMessage.java
@@ -37,6 +37,7 @@ package modele.communication;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
@@ -49,10 +50,13 @@ public abstract class TransporteurMessage extends Thread {
     // lock qui protège la liste de messages reçu
     private ReentrantLock lock = new ReentrantLock();
 
+    // liste de message recu par le transporteur
+    private List<Message> messagesRecus;
+    // liste de message envoyer par le transporteur
+    private List<Message> messagesEnvoyes; // is gonna be usefull later
+
     protected Queue<Message> fileMessages = new LinkedList<>(); // File de messages reçus
     protected boolean nackEnvoye = false; // Indique si un Nack a été envoyé
-    protected Set<Message> messagesEnvoyes = new HashSet<>(); // Ensemble de messages envoyés
-    protected Set<Message> messagesRecus = new HashSet<>(); // Ensemble de messages reçus
 
     /**
      * Constructeur, initialise le compteur de messages unique

--- a/src/modele/rover/Rover.java
+++ b/src/modele/rover/Rover.java
@@ -1,18 +1,26 @@
 package modele.rover;
 
 import modele.communication.TransporteurMessage;
+import modele.satelliteRelai.SatelliteRelai;
 import modele.communication.Message;
 
 public class Rover extends TransporteurMessage {
+    private SatelliteRelai relaiSatelitte;
+
+    public Rover(SatelliteRelai relaiSatellite){
+        this.relaiSatelitte = relaiSatellite;
+    }
+
     // Implémentation de la méthode abstraite pour Rover
     @Override
     protected void envoyerMessage(Message msg) {
-        // too complete
+        relaiSatelitte.envoyerMessageVersCentrOp((msg));
+        messageEnvoyes.add(msg);
     }
 
     // Implémentation de la méthode abstraite pour Rover
     @Override
     protected void gestionnaireMessage(Message msg) {
-        // too complete
+        System.out.println("Rover: Message reçu - " + msg.getNumero());
     }
 }

--- a/src/modele/satelliteRelai/SatelliteRelai.java
+++ b/src/modele/satelliteRelai/SatelliteRelai.java
@@ -26,7 +26,9 @@ import java.util.ArrayList;
 import java.util.Random;
 import java.util.concurrent.locks.ReentrantLock;
 
+import modele.centreControle.CentreControle;
 import modele.communication.Message;
+import modele.rover.Rover;
 import structures.FileChainee;
 
 public class SatelliteRelai extends Thread {
@@ -40,6 +42,20 @@ public class SatelliteRelai extends Thread {
     private FileChainee<Message> fcControle = new FileChainee<Message>();
     private FileChainee<Message> fcRover = new FileChainee<Message>();
 
+    //reference au CentreControle et au Rover
+    private CentreControle centreControle;
+    private Rover rover;
+
+    // Méthode pour lier le CentreControle
+    public void lierCentrOp(CentreControle centreControle) {
+        this.centreControle = centreControle;
+    }
+
+    // Méthode pour lier le Rover
+    public void lierRover(Rover rover) {
+        this.rover = rover;
+    }
+
     /**
      * Méthode permettant d'envoyer un message vers le centre d'opération
      *
@@ -49,14 +65,14 @@ public class SatelliteRelai extends Thread {
         lock.lock();
 
         try {
-            //Declarer le num random et verifier si il peut envoyer le message
+            // Declarer le num random et verifier si il peut envoyer le message
             double randNum = rand.nextDouble();
-            if(randNum >PROBABILITE_PERTE_MESSAGE){
+            if (randNum > PROBABILITE_PERTE_MESSAGE) {
 
-                //Ajouter msg a la file qui va vers le rover
+                // Ajouter msg a la file qui va vers le rover
                 fcControle.ajouterElement(msg);
-            }else{
-                //Declarer que le message est perdu si l'interference l'emporte
+            } else {
+                // Declarer que le message est perdu si l'interference l'emporte
                 System.out.println("Message Perdu!");
             }
         } finally {
@@ -73,14 +89,14 @@ public class SatelliteRelai extends Thread {
         lock.lock();
 
         try {
-            //Declarer le num random et verifier si il peut envoyer le message
+            // Declarer le num random et verifier si il peut envoyer le message
             double randNum = rand.nextDouble();
-            if(randNum >PROBABILITE_PERTE_MESSAGE){
+            if (randNum > PROBABILITE_PERTE_MESSAGE) {
 
-                //Ajouter msg a la file qui va vers le rover
+                // Ajouter msg a la file qui va vers le rover
                 fcRover.ajouterElement(msg);
-            }else{
-                //Declarer que le message est perdu si l'interference l'emporte
+            } else {
+                // Declarer que le message est perdu si l'interference l'emporte
                 System.out.println("Message Perdu!");
             }
         } finally {
@@ -92,7 +108,7 @@ public class SatelliteRelai extends Thread {
     public void run() {
         while (true) {
 
-            //Enlever les elements des 2 files
+            // Enlever les elements des 2 files
             fcControle.enleverElement();
             fcRover.enleverElement();
 


### PR DESCRIPTION
Ajout des reference entre satellite relais, centrecontrole et rover pour permettre la communication

**to note**
Rover rover et CentreControle centreControle, so utiliser raremewnt, donc je ne trouvais pas pertinant de modifier le nom des reference. Par contre SatelliteRelai et satelliteRelais revenais plusiseur fois et souvent relativement proche dans le code. Afin d'eviter toute confussion, j,ai prefere appeler la reference du modele SatelliteRelais --> relaisSatellite.


Dans CentreControle, ajouter un appel à envoyerMessageVersRover (membre de
SatelliteRelai) à la méthode envoyerMessage. Ajoutez également un appel pour ajouter
le message à la file de messages envoyés.
● Dans Rover, ajouter un appel à envoyerMessageVersCentrOp (membre de
SatelliteRelai) à la méthode envoyerMessage. Ajoutez également un appel pour ajouter
le message à la file de messages envoyés.


aussi, bizarrement cette partie etait deja faite???